### PR TITLE
Center dashboard in vertical splits

### DIFF
--- a/autoload/dashboard/utils.vim
+++ b/autoload/dashboard/utils.vim
@@ -3,7 +3,7 @@
 function! dashboard#utils#draw_center(lines) abort
   let longest_line   = max(map(copy(a:lines), 'strwidth(v:val)'))
   let centered_lines = map(copy(a:lines),
-        \ 'repeat(" ", (&columns / 2) - (longest_line / 2)) . v:val')
+        \ 'repeat(" ", (winwidth(0) / 2) - (longest_line / 2)) . v:val')
   return centered_lines
 endfunction
 


### PR DESCRIPTION
This prevents the dashboard UI from being displayed off-screen when opened in a vertical split.